### PR TITLE
interrogate potential fix

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -46,16 +46,16 @@ jobs:
           coverage run -m pytest tests
           coverage report --fail-under=100
 
-      - name: Documentation coverage with interrogate
-        run: |
-          interrogate -vv bobocep --fail-under 100
-
       - name: Upload coverage reports to Codecov
-        if: matrix.os == 'ubuntu-latest'
+        if: ${{ (matrix.os == 'ubuntu-latest') && (matrix.python-version == '3.9') }}
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
+
+      - name: Documentation coverage with interrogate
+        run: |
+          interrogate -vv bobocep --fail-under 100
 
   cd:
     name: CD

--- a/.github/workflows/cidev.yml
+++ b/.github/workflows/cidev.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
-        python-version: [ "3.9" ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -48,7 +48,7 @@ jobs:
           coverage report --fail-under=100
 
       - name: Upload coverage reports to Codecov
-        if: matrix.os == 'ubuntu-latest'
+        if: ${{ (matrix.os == 'ubuntu-latest') && (matrix.python-version == '3.9') }}
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ Flask==2.3.3
 interrogate==1.5.0
 mypy==1.5.1
 pytest==7.4.2
+setuptools==70.1.1
 sphinx==5.0.0
 sphinx-mdinclude==0.5.3
 sphinx-rtd-theme==1.1.1


### PR DESCRIPTION
Quick fix: `interrogate` package on `Python v3.12` needed extra dependency `setuptools v70.1.1`.